### PR TITLE
Fix invalid `license` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "description": "Extract the options and callback from a function's arguments easily",
   "homepage": "https://github.com/bevry/extract-opts",
   "browsers": true,
-  "license": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "keywords": [
     "opts",
     "options",


### PR DESCRIPTION
According to the official documentation (https://docs.npmjs.com/files/package.json), the current `license` field is invalid, and is not parsed correctly by certain tools. It should just be a string.

Fixes https://github.com/bevry/extract-opts/issues/4